### PR TITLE
fix: fix pre-commit hook on Windows

### DIFF
--- a/dist/pre-commit.sh
+++ b/dist/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash; c:/Program\ Files/Git/usr/bin/sh.exe
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 


### PR DESCRIPTION
use sh.exe in the git folder

fixed #9